### PR TITLE
chore: add a generic s3 backup base path for mongo

### DIFF
--- a/core/ansible/roles/mongodb-replicaset/README.md
+++ b/core/ansible/roles/mongodb-replicaset/README.md
@@ -20,7 +20,7 @@ Role Variables
 - root_domain: # if the value is db.example.com, then mongo alias would look like mongo-27017.db.example.com 
 - remote_docker_compose_exec: # remote path point to docker-compose executable script (/usr/local/bin/docker-compose)
 - mongo_rs_id: # name or ID of replica-set (default to rs)
-- s3_backup_bucket: # S3 bucket to store backup file of mongo
+- s3_backup_base_path: # S3 base path to store backup file of mongo. Format: <bucket>/path/to/dir
 - aws_dir: #remote directory contains aws credentials and config ($HOME/.aws)
 - remote_backup_dir: # directory to store backup file
 - aws_profile: # aws named profile
@@ -58,7 +58,7 @@ Including an example of how to use your role (for instance, with variables passe
         root_domain: db.example.com
         remote_docker_compose_exec: /usr/local/bin/docker-compose
         mongo_rs_id: rs
-        s3_backup_bucket: db-backup
+        s3_backup_base_path: db-backup/mongodb/dev
         aws_dir: /root/.aws
         remote_backup_dir: /root/mongodb-repl/backup
         aws_profile: profile-name

--- a/core/ansible/roles/mongodb-replicaset/tasks/main.yml
+++ b/core/ansible/roles/mongodb-replicaset/tasks/main.yml
@@ -105,11 +105,11 @@
 
     if [[ "{{ config_idx }}" == "0" ]]
     then
-      docker exec "$PRIMARY_MONGO_CONTAINER" \
+      docker exec -e initRsScript="$initRsScript" "$PRIMARY_MONGO_CONTAINER" \
       bash -c \
       'mongosh "mongodb://$MONGO_INITDB_ROOT_USERNAME:$MONGO_INITDB_ROOT_PASSWORD@127.0.0.1:{{ primary_config.port }}/?authSource=admin" --eval "$initRsScript"';
     else
-      docker exec "$PRIMARY_MONGO_CONTAINER" \
+      docker exec -e addNodeScript="$addNodeScript" "$PRIMARY_MONGO_CONTAINER" \
       bash -c \
       'mongosh "mongodb://$MONGO_INITDB_ROOT_USERNAME:$MONGO_INITDB_ROOT_PASSWORD@127.0.0.1:{{ primary_config.port }}/?authSource=admin" --eval "$addNodeScript"';
     fi;

--- a/core/ansible/roles/mongodb-replicaset/templates/s3-backup-restore.j2
+++ b/core/ansible/roles/mongodb-replicaset/templates/s3-backup-restore.j2
@@ -5,7 +5,7 @@ restore_filename=$RESTORE_FILENAME
 database=$DB_NAME
 action=$MONGO_ACTION
 
-s3_directory=/mongodb/$database
+s3_base_path={{ s3_backup_base_path }}/$database
 
 {% for mongo_conf in mongo_config %}
 current_container_name="mongo-{{ mongo_conf.port }}"
@@ -35,7 +35,7 @@ then
   -v {{ remote_backup_dir }}:/mongodb-backup \
   -v {{ aws_dir }}:/root/.aws:ro \
   illya/aws-cli \
-  s3 cp /mongodb-backup/$dump_file.gz s3://{{ s3_backup_bucket }}$s3_directory/$dump_file.gz --profile={{ aws_profile }};
+  s3 cp /mongodb-backup/$dump_file.gz s3://$s3_base_path/$dump_file.gz --profile={{ aws_profile }};
 
   rm -rf {{ remote_backup_dir }}/**;
   docker exec $main_container bash -c 'rm -rf /root/mongodb-backup';
@@ -48,7 +48,7 @@ else
   -v {{ remote_backup_dir }}:/mongodb-backup \
   -v {{ aws_dir }}:/root/.aws:ro \
   illya/aws-cli \
-  s3 cp s3://{{ s3_backup_bucket }}$s3_directory/$restore_filename.gz /mongodb-backup/ --profile={{ aws_profile }};
+  s3 cp s3://$s3_base_path/$restore_filename.gz /mongodb-backup/ --profile={{ aws_profile }};
 
   docker cp {{ remote_backup_dir }}/$restore_filename.gz $main_container:/root/mongodb-backup/$restore_filename.gz
 

--- a/core/ansible/server-setup.yml
+++ b/core/ansible/server-setup.yml
@@ -27,10 +27,10 @@
         root_domain: db.example.com
         remote_docker_compose_exec: "/usr/local/bin/docker-compose"
         mongo_rs_id: rs
-        s3_backup_bucket: db-backup
+        s3_backup_base_path: db-backup/mongodb/test-env
         aws_dir: /root/.aws
         remote_backup_dir: /root/mongodb-repl/backup
-        aws_profile: profile
+        aws_profile: profile-name
     - role: aws-cli
       vars:
         aws_cli_install_dir: /usr/local/aws-cli


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! -->
### Summary

s3_backup_base_path: <bucket>/path/to/backup/dir

### Github issues
<!--
If this pull request addresses an feature requests/bugs, please link the relevant GitHub issue-->

### Release Note
<!--
If no release notes are required, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your past-tense release note in the block below.
-->
```release-note
NONE
```

### Checklist

- [x] I have updated the solution description the PR summary and github issue(s)
- [x] I have rebase my feature/bug-fix branch to the head of master branch
- [x] I have rebase the commit list to one or few meaningful commits
- [x] I have follow the commitlint guideline [Commitlint](https://commitlint.js.org/#/concepts-commit-conventions)
- [x] I have attached evidence of my work in the PR
