### PR TITLE
fix: abstract the replicaset ID in mongo replica-set

### DIFF
--- a/core/ansible/roles/mongodb-replicaset/templates/s3-backup-restore.j2
+++ b/core/ansible/roles/mongodb-replicaset/templates/s3-backup-restore.j2
@@ -27,7 +27,7 @@ then
   docker exec \
   -e database=$database -e host_list=$host_list -e dump_file=$dump_file \
   $main_container bash -c \
-  'mkdir /root/mongodb-backup && mongodump --uri="mongodb://$MONGO_INITDB_ROOT_USERNAME:$MONGO_INITDB_ROOT_PASSWORD@$host_list/$database?authSource=admin&replicaSet=rs&ssl=false"  --archive="/root/mongodb-backup/$dump_file.gz" --gzip';
+  'mkdir /root/mongodb-backup && mongodump --uri="mongodb://$MONGO_INITDB_ROOT_USERNAME:$MONGO_INITDB_ROOT_PASSWORD@$host_list/$database?authSource=admin&replicaSet={{ mongo_rs_id }}&ssl=false"  --archive="/root/mongodb-backup/$dump_file.gz" --gzip';
 
   docker cp $main_container:/root/mongodb-backup/$dump_file.gz {{ remote_backup_dir }}/$dump_file.gz;
 
@@ -55,7 +55,7 @@ else
   docker exec \
   -e database=$database -e host_list=$host_list -e restore_file=$restore_filename \
   $main_container bash -c \
-  'mongorestore --uri="mongodb://$MONGO_INITDB_ROOT_USERNAME:$MONGO_INITDB_ROOT_PASSWORD@$host_list/$database?authSource=admin&replicaSet=rs&ssl=false"  --archive="/root/mongodb-backup/$restore_file.gz" --gzip';
+  'mongorestore --uri="mongodb://$MONGO_INITDB_ROOT_USERNAME:$MONGO_INITDB_ROOT_PASSWORD@$host_list/$database?authSource=admin&replicaSet={{ mongo_rs_id }}&ssl=false"  --archive="/root/mongodb-backup/$restore_file.gz" --gzip';
 
   rm -rf {{ remote_backup_dir }}/**;
   docker exec $main_container bash -c 'rm -rf /root/mongodb-backup';


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! -->
### Summary

Add the variable template in the s3-backup-restore script to abstract the replicaset ID

### Github issues
<!--
If this pull request addresses an feature requests/bugs, please link the relevant GitHub issue-->

### Release Note
<!--
If no release notes are required, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your past-tense release note in the block below.
-->
```release-note
```

### Checklist

- [x] I have updated the solution description the PR summary and github issue(s)
- [x] I have rebase my feature/bug-fix branch to the head of master branch
- [x] I have rebase the commit list to one or few meaningful commits
- [x] I have follow the commitlint guideline [Commitlint](https://commitlint.js.org/#/concepts-commit-conventions)
- [x] I have attached evidence of my work in the PR
